### PR TITLE
fix：修復無法藉由 tag 刪除按鈕，取消畫面中沒有的 checkbox

### DIFF
--- a/pages/createVoting.html
+++ b/pages/createVoting.html
@@ -609,7 +609,12 @@
 
                                 //綁定該 uid 對應 checkbox
                                 const checkedCheckbox = document.querySelector(`input[data-uid=${uid}]`)
-                                checkedCheckbox.checked = false
+                                //如果有綁定到該 checkbox 才執行取消 checked
+                                if (checkedCheckbox){
+                                    checkedCheckbox.checked = false
+                                }
+
+                                //刪除清單中的店家
                                 delete checkedStoreList[uid]
 
                                 renderCheckedStore()


### PR DESCRIPTION
1. 原 bug 直接於 tag 刪除按鈕點擊後，將對應 checkbox 取消勾選，但若畫面上可能因為換頁等因素，並未渲染該 checkbox 導致無法綁定，將會跳錯。
2. 新增 if 判斷若有綁定 checkbox 才取消勾選。